### PR TITLE
fix: Add useFocusEffect hook

### DIFF
--- a/screens/AppStack/RemindersScreen.tsx
+++ b/screens/AppStack/RemindersScreen.tsx
@@ -9,7 +9,8 @@ import {
   ListRenderItemInfo,
 } from 'react-native'
 import { NativeStackScreenProps } from '@react-navigation/native-stack'
-import { useState, useEffect } from 'react'
+import { useFocusEffect } from '@react-navigation/native'
+import { useState, useCallback } from 'react'
 
 import { POKE_URL } from '@env'
 import { AppStackParamList } from '../../types'
@@ -51,26 +52,33 @@ function ReminderScreen({ navigation }: RemindersScreenNavigationProps) {
   const [reminders, setReminders] = useState([])
   const [isLoading, setLoading] = useState(false)
 
-  useEffect(() => {
-    const getReminders = async () => {
-      try {
-        setLoading(true)
-        const response = await fetch(`${POKE_URL}/reminders`)
-        const reminders = await response.json()
+  useFocusEffect(
+    useCallback(() => {
+      let isActive = true
 
-        setReminders(reminders)
-      } catch (error: any) {
-        ErrorAlert({
-          title: 'Error on Fetching Pokes',
-          message: error?.message,
-        })
-      } finally {
-        setLoading(false)
+      const getReminders = async () => {
+        try {
+          setLoading(true)
+          const response = await fetch(`${POKE_URL}/reminders`)
+          const reminders = await response.json()
+          if (isActive) {
+            setReminders(reminders)
+          }
+        } catch (error: any) {
+          ErrorAlert({
+            title: 'Error on Fetching Pokes',
+            message: error?.message,
+          })
+        } finally {
+          setLoading(false)
+        }
       }
-    }
-
-    getReminders()
-  }, [])
+      getReminders()
+      return () => {
+        isActive = false
+      }
+    }, [])
+  )
 
   const renderReminder: ListRenderItem<Reminder> = (
     info: ListRenderItemInfo<Reminder>


### PR DESCRIPTION
This PR:

- [x] Add `useFocusEffect` hook so that every time user focus on reminders screen, it will run the side effect of fetching reminders
- [x] Includes useCallBack to avoid running the effect too often, does not redefine fetch reminders function
- [x] Includes cleanup with isActive state to avoid inconsistent data due to race conditions on API calls