### PR TITLE
feat: send JWT token over when making fetch requests

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,7 +1,5 @@
-import { useEffect, useState } from 'react'
 import shallow from 'zustand/shallow'
 
-import { supabase } from '../lib/supabase'
 import { useStore } from '../store'
 
 function useAuth() {

--- a/hooks/useFetch.ts
+++ b/hooks/useFetch.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react'
+
+import useAuth from '../hooks/useAuth'
+
+function useFetch() {
+  const { isAuthenticated, session } = useAuth()
+
+  const pokeFetch = useCallback(
+    (endpoint: RequestInfo, options?: RequestInit | undefined) => {
+      const headers = new Headers()
+
+      if (isAuthenticated && session?.access_token) {
+        headers.append('Authorization', `Bearer ${session.access_token}`)
+      }
+
+      return fetch(endpoint, {
+        ...options,
+        headers,
+      })
+    },
+    [isAuthenticated]
+  )
+
+  return { fetch: pokeFetch }
+}
+
+export default useFetch

--- a/screens/AppStack/CreateReminderScreen.tsx
+++ b/screens/AppStack/CreateReminderScreen.tsx
@@ -10,6 +10,7 @@ import { POKE_URL } from '@env'
 import { AppStackParamList } from '../../types'
 import { styles } from '../styles'
 import { ErrorAlert, ErrorText } from '../utils'
+import useFetch from '../../hooks/useFetch'
 
 type CreateReminderScreenNavigationProps = NativeStackScreenProps<
   AppStackParamList,
@@ -51,13 +52,14 @@ function CreateReminderScreen({
     resolver: yupResolver(createReminderSchema),
     defaultValues: { text: '', notificationTime: '', notificationDays: [] },
   })
-
   const [selectedDays, setSelectedDays] = useState<number[]>([])
+  const { fetch } = useFetch()
 
   const onSelectedDayChange = (selectedDays: number[]) => {
     setSelectedDays(selectedDays)
     setValue('notificationDays', selectedDays)
   }
+
   const onChangeField = useCallback(
     (name: ChangeFieldInput) => (text: string) => {
       setValue(name, text)
@@ -74,6 +76,7 @@ function CreateReminderScreen({
           'Content-Type': 'application/json',
         },
       })
+
       navigation.navigate('Reminders')
     } catch (error: any) {
       ErrorAlert({ title: 'Error Creating Reminder', message: error?.message })

--- a/screens/AppStack/RemindersScreen.tsx
+++ b/screens/AppStack/RemindersScreen.tsx
@@ -14,6 +14,7 @@ import { useState, useEffect } from 'react'
 import { POKE_URL } from '@env'
 import { AppStackParamList } from '../../types'
 import { numToDays, ErrorAlert } from '../utils'
+import useFetch from '../../hooks/useFetch'
 
 type RemindersScreenNavigationProps = NativeStackScreenProps<
   AppStackParamList,
@@ -50,6 +51,7 @@ const Item = ({ reminder }: { reminder: Reminder }) => {
 function ReminderScreen({ navigation }: RemindersScreenNavigationProps) {
   const [reminders, setReminders] = useState([])
   const [isLoading, setLoading] = useState(false)
+  const { fetch } = useFetch()
 
   useEffect(() => {
     const getReminders = async () => {


### PR DESCRIPTION
### tl;dr

- [x] Resolves #9 

### Description

I decided to go with a custom hook that will allow us to get a custom `fetch` client. The hook allows us to use the `useAuth` hook which is super helpful for appending the JWT for users. If we need to make a network request outside of a React component, we can just use regular ol' `fetch`.